### PR TITLE
Grow trie only when collision is found

### DIFF
--- a/inner.go
+++ b/inner.go
@@ -321,7 +321,7 @@ func (in *inner) Unmarshal(buf []byte) {
 		if ltype == innerNode {
 			in.left = createInner(in.store, in.bit+1, leftIdx, leftPos, leftHash)
 		} else if ltype == leafNode {
-			in.left = createLeaf(in.store, leftIdx, leftPos)
+			in.left = createLeaf(in.store, leftIdx, leftPos, leftHash)
 		}
 	}
 	if rtype != nullNode {
@@ -330,7 +330,7 @@ func (in *inner) Unmarshal(buf []byte) {
 		if rtype == innerNode {
 			in.right = createInner(in.store, in.bit+1, rightIdx, rightPos, rightHash)
 		} else if rtype == leafNode {
-			in.right = createLeaf(in.store, rightIdx, rightPos)
+			in.right = createLeaf(in.store, rightIdx, rightPos, rightHash)
 		}
 	}
 }

--- a/inner.go
+++ b/inner.go
@@ -74,12 +74,8 @@ func (in *inner) Allocate() {
 	}
 }
 
-func (in *inner) Pos() uint64 {
-	return in.pos
-}
-
-func (in *inner) Idx() uint64 {
-	return in.idx
+func (in *inner) Position() (uint64, uint64) {
+	return in.idx, in.pos
 }
 
 func (in *inner) Get(key [size]byte) ([]byte, error) {
@@ -138,10 +134,7 @@ func (in *inner) insert(n *leaf) error {
 		}
 		switch tmp := in.right.(type) {
 		case *inner:
-			err := tmp.Insert(n)
-			if err != nil {
-				return err
-			}
+			return tmp.Insert(n)
 		case *leaf:
 			if in.bit == lastBit {
 				return tmp.Put(n.key, n.value)
@@ -150,10 +143,7 @@ func (in *inner) insert(n *leaf) error {
 				return err
 			}
 			in.right = newInner(in.store, in.bit+1)
-			err := in.right.(*inner).Insert(n, tmp)
-			if err != nil {
-				return err
-			}
+			return in.right.(*inner).Insert(n, tmp)
 
 		}
 		return nil
@@ -164,10 +154,7 @@ func (in *inner) insert(n *leaf) error {
 	}
 	switch tmp := in.left.(type) {
 	case *inner:
-		err := tmp.Insert(n)
-		if err != nil {
-			return err
-		}
+		return tmp.Insert(n)
 	case *leaf:
 		if in.bit == lastBit {
 			return tmp.Put(n.key, n.value)
@@ -176,10 +163,7 @@ func (in *inner) insert(n *leaf) error {
 			return err
 		}
 		in.left = newInner(in.store, in.bit+1)
-		err := in.left.(*inner).Insert(n, tmp)
-		if err != nil {
-			return err
-		}
+		return in.left.(*inner).Insert(n, tmp)
 	}
 	return nil
 }
@@ -280,13 +264,11 @@ func (in *inner) MarshalTo(buf []byte) {
 		rightHash = zerosHash[:]
 	)
 	if in.left != nil {
-		leftIdx = in.left.Idx()
-		leftPos = in.left.Pos()
+		leftIdx, leftPos = in.left.Position()
 		leftHash = in.left.Hash()
 	}
 	if in.right != nil {
-		rightIdx = in.right.Idx()
-		rightPos = in.right.Pos()
+		rightIdx, rightPos = in.right.Position()
 		rightHash = in.right.Hash()
 	}
 	order.PutUint64(buf[2:], leftIdx)

--- a/inner.go
+++ b/inner.go
@@ -94,6 +94,10 @@ func (in *inner) Get(key [size]byte) ([]byte, error) {
 	return in.left.Get(key)
 }
 
+func (in *inner) Sync() error {
+	return in.sync()
+}
+
 func (in *inner) sync() error {
 	if !in.synced && !in.dirty {
 		// sync the state from disk
@@ -139,7 +143,7 @@ func (in *inner) insert(n *leaf) error {
 			if in.bit == lastBit {
 				return tmp.Put(n.key, n.value)
 			}
-			if err := tmp.sync(); err != nil {
+			if err := tmp.Sync(); err != nil {
 				return err
 			}
 			in.right = newInner(in.store, in.bit+1)
@@ -159,7 +163,7 @@ func (in *inner) insert(n *leaf) error {
 		if in.bit == lastBit {
 			return tmp.Put(n.key, n.value)
 		}
-		if err := tmp.sync(); err != nil {
+		if err := tmp.Sync(); err != nil {
 			return err
 		}
 		in.left = newInner(in.store, in.bit+1)

--- a/inner.go
+++ b/inner.go
@@ -249,18 +249,8 @@ func (in *inner) Hash() []byte {
 	}
 	h := digestPool.Get().(hash.Hash)
 	h.Write([]byte{innerDomain})
-	if in.left != nil && in.right != nil {
-		c := results.Get().(chan []byte)
-		go func() {
-			c <- in.rhash()
-		}()
-		h.Write(in.lhash())
-		h.Write(<-c)
-		results.Put(c)
-	} else {
-		h.Write(in.lhash())
-		h.Write(in.rhash())
-	}
+	h.Write(in.lhash())
+	h.Write(in.rhash())
 	in.hash = h.Sum(in.hash)
 	h.Reset()
 	digestPool.Put(h)

--- a/leaf.go
+++ b/leaf.go
@@ -43,6 +43,10 @@ type leaf struct {
 	valueIdx, valuePos uint64
 }
 
+func (l *leaf) Sync() error {
+	return l.sync()
+}
+
 func (l *leaf) sync() error {
 	if !l.synced && !l.dirty {
 		buf := make([]byte, l.Size())

--- a/leaf.go
+++ b/leaf.go
@@ -10,11 +10,12 @@ func bitSet(key [32]byte, index int) bool {
 	return (key[pos] & (1 << bit)) > 0
 }
 
-func createLeaf(store *FileStore, idx, pos uint64) *leaf {
+func createLeaf(store *FileStore, idx, pos uint64, hash []byte) *leaf {
 	return &leaf{
 		store: store,
 		pos:   pos,
 		idx:   idx,
+		hash:  hash,
 	}
 }
 

--- a/leaf.go
+++ b/leaf.go
@@ -61,12 +61,8 @@ func (l *leaf) sync() error {
 	return nil
 }
 
-func (l *leaf) Pos() uint64 {
-	return l.pos
-}
-
-func (l *leaf) Idx() uint64 {
-	return l.idx
+func (l *leaf) Position() (uint64, uint64) {
+	return l.idx, l.pos
 }
 
 func (l *leaf) Put(key [32]byte, value []byte) error {

--- a/proof.go
+++ b/proof.go
@@ -1,6 +1,8 @@
 package urkeltrie
 
-import "bytes"
+import (
+	"bytes"
+)
 
 func NewProof(hint int) *Proof {
 	return &Proof{

--- a/proof_test.go
+++ b/proof_test.go
@@ -22,6 +22,24 @@ func TestTreeProve(t *testing.T) {
 	require.True(t, proof.VerifyMembership(tree.Hash(), key, value))
 }
 
+func TestTreeProvePersistent(t *testing.T) {
+	tree, closer := setupFullTreeP(t, 4)
+	defer closer()
+
+	var (
+		key = make([]byte, 10)
+	)
+	rand.Read(key)
+	require.NoError(t, tree.Put(key, key))
+
+	root := tree.Hash()
+	require.NoError(t, tree.Commit())
+
+	proof := NewProof(256)
+	require.NoError(t, tree.GenerateProof(key, proof))
+	require.True(t, proof.VerifyMembership(root, key, key))
+}
+
 func BenchmarkGenerateProof(b *testing.B) {
 	rand.Seed(time.Now().Unix())
 	tree := setupFullTree(b, 10000)

--- a/tree.go
+++ b/tree.go
@@ -31,8 +31,6 @@ var (
 
 	digestPool = sync.Pool{New: func() interface{} { return hasher() }}
 	innerPool  = sync.Pool{New: func() interface{} { return make([]byte, innerSize) }}
-	// results used for async hash computation
-	results = sync.Pool{New: func() interface{} { return make(chan []byte, 1) }}
 )
 
 func init() {

--- a/tree.go
+++ b/tree.go
@@ -58,8 +58,7 @@ type node interface {
 	Hash() []byte
 	// Pos and Idx of the node in the file store.
 	Allocate()
-	Pos() uint64
-	Idx() uint64
+	Position() (uint64, uint64)
 	Commit() error
 	Prove([size]byte, *Proof) error
 }
@@ -262,8 +261,9 @@ func (ft *FlushTree) Commit() error {
 
 func marshalVersionTo(version uint64, node *inner, buf []byte) {
 	order.PutUint64(buf, version)
-	order.PutUint64(buf[8:], node.Idx())
-	order.PutUint64(buf[16:], node.Pos())
+	idx, pos := node.Position()
+	order.PutUint64(buf[8:], idx)
+	order.PutUint64(buf[16:], pos)
 	copy(buf[24:], node.Hash())
 }
 

--- a/tree.go
+++ b/tree.go
@@ -57,7 +57,6 @@ func sum(key []byte) (rst [size]byte) {
 
 type node interface {
 	Get([size]byte) ([]byte, error)
-	Put([size]byte, []byte) error
 	Hash() []byte
 	// Pos and Idx of the node in the file store.
 	Allocate()
@@ -102,7 +101,8 @@ func (t *Tree) PutRaw(key [size]byte, value []byte) error {
 	if t.root == nil {
 		t.root = newInner(t.store, 0)
 	}
-	return t.root.Put(key, value)
+	leaf := newLeaf(t.store, key, value)
+	return t.root.Insert(leaf)
 }
 
 func (t *Tree) Hash() []byte {

--- a/tree.go
+++ b/tree.go
@@ -56,11 +56,11 @@ func sum(key []byte) (rst [size]byte) {
 type node interface {
 	Get([size]byte) ([]byte, error)
 	Hash() []byte
-	// Pos and Idx of the node in the file store.
 	Allocate()
 	Position() (uint64, uint64)
 	Commit() error
 	Prove([size]byte, *Proof) error
+	Sync() error
 }
 
 func NewTree(store *FileStore) *Tree {

--- a/tree_test.go
+++ b/tree_test.go
@@ -112,24 +112,6 @@ func TestTreeCommitPersistent(t *testing.T) {
 	}
 }
 
-func TestTreeProvePersistent(t *testing.T) {
-	tree, closer := setupFullTreeP(t, 100)
-	defer closer()
-
-	var (
-		key = make([]byte, 10)
-	)
-	rand.Read(key)
-	require.NoError(t, tree.Put(key, key))
-
-	root := tree.Hash()
-	require.NoError(t, tree.Commit())
-
-	proof := NewProof(256)
-	require.NoError(t, tree.GenerateProof(key, proof))
-	require.True(t, proof.VerifyMembership(root, key, key))
-}
-
 func TestTreeMultiFiles(t *testing.T) {
 	tmp, err := ioutil.TempDir("", "testing-urkel")
 	require.NoError(t, err)


### PR DESCRIPTION
~250ms to commit 5000 entries, ~2,75s to commit 40000 entries. Tree flushed periodically, when 500 leafs are added. 16-30mb of memory consumed consistently. 